### PR TITLE
[1주차 과제] TDD로 Point 서비스 동시성 제어하기

### DIFF
--- a/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
@@ -233,6 +233,8 @@ class PointServiceTest {
     assertThat(result.id()).isEqualTo(userId);
     assertThat(result.point()).isEqualTo(point + amounts.stream().reduce(0L, Long::sum));
     assertThat(result.updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
+    final var pointHistories = pointHistoryRepository.findAllByUserId(userId);
+    assertThat(pointHistories).hasSize(numOperations);
   }
 
   // NOTE: Test 간의 의존성을 없애기 위해 DirtiesContext를 사용합니다.
@@ -264,6 +266,8 @@ class PointServiceTest {
     assertThat(result.id()).isEqualTo(userId);
     assertThat(result.point()).isEqualTo(point - amounts.stream().reduce(0L, Long::sum));
     assertThat(result.updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
+    final var pointHistories = pointHistoryRepository.findAllByUserId(userId);
+    assertThat(pointHistories).hasSize(numOperations);
   }
 
   // NOTE: Test 간의 의존성을 없애기 위해 DirtiesContext를 사용합니다.
@@ -297,13 +301,13 @@ class PointServiceTest {
 
     // then
     final var result = pointRepository.findById(userId).orElseThrow();
-    final var pointHistories = pointHistoryRepository.findAllByUserId(userId);
-    System.out.println(pointHistories);
     assertThat(result.id()).isEqualTo(userId);
     assertThat(result.point()).isEqualTo(
         point + amounts.stream().filter(i -> i % 2 == 0).reduce(0L, Long::sum)
             - amounts.stream().filter(i -> i % 2 != 0).reduce(0L, Long::sum));
     assertThat(result.updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
+    final var pointHistories = pointHistoryRepository.findAllByUserId(userId);
+    assertThat(pointHistories).hasSize(numOperations);
   }
 
 }

--- a/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
@@ -10,6 +10,9 @@ import io.hhplus.tdd.point.entity.UserPoint;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.PointRepository;
 import io.hhplus.tdd.point.type.TransactionType;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -199,4 +202,108 @@ class PointServiceTest {
     assertThat(result.get(1).type()).isEqualTo(TransactionType.USE);
     assertThat(result.get(1).updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
   }
+
+  // NOTE: Test 간의 의존성을 없애기 위해 DirtiesContext를 사용합니다.
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  @Test
+  @DisplayName("포인트 충전 동시성 검증")
+  void shouldSuccessfullyChargePointConcurrently() {
+    // given
+    final Long userId = 1L;
+    final Long point = 50L;
+    final UserPoint userPoint = UserPoint.from(userId, point, System.currentTimeMillis());
+    // NOTE: insert가 없어 update로 초기값 설정
+    pointRepository.update(userPoint);
+    final int numOperations = 10;
+    final List<Long> amounts = IntStream.range(0, numOperations)
+        .mapToObj(i -> 100L * (i + 1))
+        .toList();
+
+    List<CompletableFuture<Void>> futures = amounts.stream()
+        .map(i -> CompletableFuture.runAsync(
+            () -> target.charge(UserPointCommand.Charge.from(userId, i)))
+        )
+        .toList();
+
+    // when
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+    // then
+    final var result = pointRepository.findById(userId).orElseThrow();
+    assertThat(result.id()).isEqualTo(userId);
+    assertThat(result.point()).isEqualTo(point + amounts.stream().reduce(0L, Long::sum));
+    assertThat(result.updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
+  }
+
+  // NOTE: Test 간의 의존성을 없애기 위해 DirtiesContext를 사용합니다.
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  @Test
+  @DisplayName("포인트 사용 동시성 검증")
+  void shouldSuccessfullyUsePointConcurrently() {
+    // given
+    final Long userId = 1L;
+    final Long point = 100000L;
+    final UserPoint userPoint = UserPoint.from(userId, point, System.currentTimeMillis());
+    // NOTE: insert가 없어 update로 초기값 설정
+    pointRepository.update(userPoint);
+    final int numOperations = 10;
+    final List<Long> amounts = IntStream.range(0, numOperations)
+        .mapToObj(i -> 50L * (i + 1))
+        .toList();
+
+    List<CompletableFuture<Void>> futures = amounts.stream()
+        .map(i -> CompletableFuture.runAsync(() -> target.use(UserPointCommand.Use.from(userId, i)))
+        )
+        .toList();
+
+    // when
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+    // then
+    final var result = pointRepository.findById(userId).orElseThrow();
+    assertThat(result.id()).isEqualTo(userId);
+    assertThat(result.point()).isEqualTo(point - amounts.stream().reduce(0L, Long::sum));
+    assertThat(result.updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
+  }
+
+  // NOTE: Test 간의 의존성을 없애기 위해 DirtiesContext를 사용합니다.
+  @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+  @Test
+  @DisplayName("포인트 충전/사용 동시성 검증")
+  void shouldSuccessfullyChargeAndUsePointConcurrently() {
+    // given
+    final Long userId = 1L;
+    final Long point = 100000L;
+    final UserPoint userPoint = UserPoint.from(userId, point, System.currentTimeMillis());
+    // NOTE: insert가 없어 update로 초기값 설정
+    pointRepository.update(userPoint);
+    final int numOperations = 10;
+    final List<Long> amounts = IntStream.range(0, numOperations)
+        .mapToObj(i -> 50L * (i + 1))
+        .toList();
+
+    List<CompletableFuture<Void>> futures = amounts.stream()
+        .map(i -> CompletableFuture.runAsync(() -> {
+          if (i % 2 == 0) {
+            target.charge(UserPointCommand.Charge.from(userId, i));
+          } else {
+            target.use(UserPointCommand.Use.from(userId, i));
+          }
+        }))
+        .toList();
+
+    // when
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+    // then
+    final var result = pointRepository.findById(userId).orElseThrow();
+    final var pointHistories = pointHistoryRepository.findAllByUserId(userId);
+    System.out.println(pointHistories);
+    assertThat(result.id()).isEqualTo(userId);
+    assertThat(result.point()).isEqualTo(
+        point + amounts.stream().filter(i -> i % 2 == 0).reduce(0L, Long::sum)
+            - amounts.stream().filter(i -> i % 2 != 0).reduce(0L, Long::sum));
+    assertThat(result.updateMillis()).isLessThanOrEqualTo(System.currentTimeMillis());
+  }
+
 }


### PR DESCRIPTION
# 변경사항
- PointService 충전, 사용 부분 Lock을 이용한 동시성 제어 (UserId 별로 Lock 관리)
- 동시성 제어에 대한 통합 테스트 작성

# 리뷰 포인트
- ReentrantLock 만으로는 userId 별로 Lock 관리가 안된다고 생각해서 ConcurrentHashMap 과 같이 활용했습니다.
- Atomic Class의 경우 UserPoint를 수정해서 DB 코드까지 수정을 해야해서 사용을 안했습니다.
- Atomic Class의 경우 래핑하는 방식 DB 코드 수정 없이 가능했을 수도 있을 것 같은데 이루고자하는 목표에 비해 코드량이 많아지지 않을까 싶었습니다.
- 동시성 통합테스트의 경우도 성능 체크할땐 다른 userId도 넣어가면서 작업을 했었는데 실질적인 테스트 코드에선 제외했습니다.
- 제외한 이유는 동시성 테스트만을 위한 목적인데 다양한 환경(다양한 userId)의 Test가 필요할까? 가 의문이였습니다.
- 지금 주어진 환경에서 Best Practice가 뭔지 궁금하며 제가 생각한 과정들 중 피드백 해주실게 있다면 부탁드림다!

ps. Default, STEP1으로 PR을 나눌까하다가 `포인트 충전, 사용에 대한 정책 추가 (잔고 부족, 최대 잔고 등)` 이 부분을 이미 전 PR에서 같이 작업을 했습니다. 참고부탁드립니다.